### PR TITLE
fix color selection with touch screen

### DIFF
--- a/src/components/ColorSpace/ColorSpace.tsx
+++ b/src/components/ColorSpace/ColorSpace.tsx
@@ -16,7 +16,7 @@ type ColorSpaceProps = {
 
 const ColorSpace = (props: ColorSpaceProps) => {
   const { hsv, onChange, currentHue } = props
-  const isMouseDown = React.useRef<boolean>(false)
+  const isPointerDown = React.useRef<boolean>(false)
   const spaceRef = React.useRef<HTMLDivElement>(null)
   const [isActive, setIsActive] = React.useState<boolean>(false)
 
@@ -35,15 +35,15 @@ const ColorSpace = (props: ColorSpaceProps) => {
     }
   })
 
-  const handleMouseUp = React.useCallback(() => {
-    if (isMouseDown.current) {
-      isMouseDown.current = false
+  const handlePointerUp = React.useCallback(() => {
+    if (isPointerDown.current) {
+      isPointerDown.current = false
       setIsActive(false)
     }
   }, [])
 
-  const handleMouseMove = React.useCallback((event: MouseEvent) => {
-    if (isMouseDown.current) {
+  const handlePointerMove = React.useCallback((event: PointerEvent) => {
+    if (isPointerDown.current) {
       moveThumb(event.clientX, event.clientY)
     }
     // moveThumb is a useEvent
@@ -51,20 +51,20 @@ const ColorSpace = (props: ColorSpaceProps) => {
   }, [])
 
   React.useEffect(() => {
-    document.addEventListener('mousemove', handleMouseMove, false)
-    document.addEventListener('mouseup', handleMouseUp, false)
+    document.addEventListener('pointermove', handlePointerMove, false)
+    document.addEventListener('pointerup', handlePointerUp, false)
 
     return () => {
-      document.removeEventListener('mousemove', handleMouseMove, false)
-      document.removeEventListener('mouseup', handleMouseUp, false)
+      document.removeEventListener('pointermove', handlePointerMove, false)
+      document.removeEventListener('pointerup', handlePointerUp, false)
     }
-  }, [handleMouseUp, handleMouseMove])
+  }, [handlePointerUp, handlePointerMove])
 
-  const handleMouseDown = (
-    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  const handlePointerDown = (
+    event: React.MouseEvent<HTMLDivElement, PointerEvent>
   ) => {
     event.preventDefault()
-    isMouseDown.current = true
+    isPointerDown.current = true
     moveThumb(event.clientX, event.clientY)
     setIsActive(true)
   }
@@ -93,11 +93,12 @@ const ColorSpace = (props: ColorSpaceProps) => {
 
   return (
     <Styled.Space
-      onMouseDown={handleMouseDown}
+      onPointerDown={handlePointerDown}
       ref={spaceRef}
       className="MuiColorInput-ColorSpace"
       style={{
-        backgroundColor: `hsl(${currentHue} 100% 50%)`
+        backgroundColor: `hsl(${currentHue} 100% 50%)`,
+        touchAction: 'none'
       }}
       role="slider"
       aria-valuetext={`Saturation ${round(


### PR DESCRIPTION
Currently you cannot drag the circle in the ColorSpace with touch. I fix this by using pointer events instead of mouse events to receive touch move events. I also add `touch-action:none` to ColorSpace to receive `pointermove` events. Otherwise the browser would assume a scroll gesture takes place and stop sending `pointermove` events after the first few.