### PR TITLE
Add default values for ColorButton in case theme does not use the defaults

### DIFF
--- a/src/components/ColorButton/ColorButton.tsx
+++ b/src/components/ColorButton/ColorButton.tsx
@@ -29,6 +29,8 @@ const ColorButton = (props: ColorButtonProps) => {
         cursor: disablePopover ? 'default' : undefined
       }}
       className={`MuiColorInput-Button ${className || ''}`}
+      variant="text"
+      disableElevation={false}
       {...restButtonProps}
     />
   )


### PR DESCRIPTION
Hi there - big fan of this component. However, it glitches a little bit visually in my custom MUI theme, see below:

![ezgif-4-a3e1575fba](https://github.com/viclafouch/mui-color-input/assets/10974701/fa1f8c09-ccec-43c2-aae7-91512ce313b9)

The reason for this is my custom theme, I have forced default values for Button's `variant` and `disableElevation` props to be different from the MUI defaults, namely:

```
export const MuiButton = {
  defaultProps: {
    variant: "outlined",
    disableElevation: true,
  },
...
```

But the ColorButton component in this package assumes the default props for `Button` are the same as MUI's. Therefore to fix this I have added in the props to force it to always have `variant="text"` and `disableElevation={false}`, so it is always the same as the MUI default props even if a custom theme has been applied.