### PR TITLE
Accept React 19 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "@emotion/styled": "^11.13.0",
     "@mui/material": "^6.0.0",
     "@types/react": "^18.3.12",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^18.3.1 || ^19.0.0",
+    "react-dom": "^18.3.1 || ^19.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
Hi! Would you consider this PR?

There are a few steps involved in supporting React 19 in `mui-color-input`:

1. Accept React 19 in `mui-color-input` peer dependencies, & releasing a new version
1. Upgrade `/` to React 19, currently blocked on `@chromatic-com/storybook` upgrading to a new version of `react-confetti`
1. Upgrade `docs/` to React 19, currently blocked on:
    1. A new version of `mui-color-input` being released, due to the way this repository depends on itself,
    1. https://github.com/algolia/docsearch/issues/2407 (& failures in https://github.com/algolia/docsearch/pull/2388)

I'm happy to contribute (1), (2) and (3.1) if you're open to it, starting with this PR, with the caveat that I'll be out for travel next week so there might be a slight delay due to that.

I've confirmed, by force updating the dependencies, that both the storybook and the tests are fine, and the color input works as expected. Thank you for making this library :)